### PR TITLE
Fix regexp for rpm-related RPMs

### DIFF
--- a/store_id_program/main.go
+++ b/store_id_program/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
     reader := bufio.NewReader(os.Stdin)
-    re     := regexp.MustCompile("[^/]+.rpm")
+    re     := regexp.MustCompile(`[^/]+\.rpm`)
 
     for true {
         line, _  := reader.ReadString('\n')


### PR DESCRIPTION
Without this, I got errors during installation, and in squid logs got e.g.:

access.log:1454404609.517      0 192.168.3.13 TCP_MISS_ABORTED/200 106598 GET http://mirror.isoc.org.il/pub/fedora/releases/23/Server/x86_64/os/Packages/r/rpm-build-libs-4.13.0-0.rc1.3.fc23.x86_64.rpm - HIER_NONE/- application/x-redhat-package-manager

checking the sizes in /tmp/*.log on the installed host during installation compared with the sizes on the mirror, lead me to realize that store_id_program might have given two different packages a single key.

I know nothing about 'go', and only managed to do this with a quick net search for 'go regexp literal dot'.
