### PR TITLE
Differentiate between distributions

### DIFF
--- a/store_id_program/store_id_program.py
+++ b/store_id_program/store_id_program.py
@@ -1,7 +1,8 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 
 
 import re
+from six.moves import input
 import sys
 
 
@@ -16,7 +17,7 @@ def main():
     ]
 
     while True:
-        line = raw_input('')
+        line = input('')
         parts = line.split(' ')
         url = parts[0]
         distro = next(

--- a/store_id_program/store_id_program.py
+++ b/store_id_program/store_id_program.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python2
+
+
+import re
+import sys
+
+
+def main():
+    rpm_re = re.compile('[^/]+\.rpm')
+    distros = [
+        'centos',
+        'redhat',
+        'fedora',
+        'opensuse',
+        'suse',
+    ]
+
+    while True:
+        line = raw_input('')
+        parts = line.split(' ')
+        url = parts[0]
+        distro = next(
+            (
+                d for d in distros
+                if d in url.lower()
+            ),
+            'unknown'
+        )
+        search_res = rpm_re.search(url)
+        print(
+            "OK store-id=%s\n" % (
+                'distro:%s:%s' % (distro, search_res.group())
+                if search_res else url
+            )
+        )
+        sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Add store_id_program.py, which prepends the distribution, as hopefully
found in the url, to the store-id, so that same RPM name from different
distributions will get different store-ids.

I was too lazy to learn enough go to fix this in the original implementation, so wrote in python instead. This worked for me.

Without this, if I use the same proxy cache to install e.g. both RHEL and centos, sometimes there are conflicts, which get the installation stuck and eventually fail.
